### PR TITLE
feat: update readme instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM nikolaik/python-nodejs:python3.11-nodejs20
 
 # Install Git and necessary dependencies
 RUN apt-get update && \
-    apt-get install -y git && \
+    apt-get install -y git libonig-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Set the working directory

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It provides resource scanning and remediation based on Rego policy rules. Scruti
 ## Prerequisites
 
 - Docker installed on your system ([Install Docker](https://docs.docker.com/get-docker/))
+- Docker Compose installed on your system ([Install Docker Compose](https://docs.docker.com/compose/install/))
 
 ## How to Run
 
@@ -20,19 +21,19 @@ It provides resource scanning and remediation based on Rego policy rules. Scruti
 
    ```bash
    cd ScrutinyCSPM
-   cp docker/production/Dockerfile .
    ```
 
-3. Build the Docker image:
+3. Run the Docker container and it's dependencies:
 
    ```bash
-   docker build -t scrutiny_cspm .
+   docker compose up -d
    ```
+   
 
-4. Run the Docker container in interactive mode and allocate a pseudo-TTY:
+4. You can now access the ScrutinyCSPM program by entering the following command:
 
    ```bash
-   docker run -it scrutiny_cspm
+   docker exec -it scrutiny-cspm /bin/bash -c "python /scrutinycspm/cli/main.py"
    ```
 
 5. You can now enter commands to interact with the program.

--- a/cli/main.py
+++ b/cli/main.py
@@ -5,14 +5,14 @@ from typing import Any, Dict
 from commands.command_manager import CommandManager
 import logging
 import importlib
-
+import argparse
 
 @hydra.main(config_path="config", config_name="conf", version_base=None)
 def main(cfg: DictConfig) -> None:
     logging.basicConfig(level=cfg.logging.level, filename="app.log")
-    
+
     print("Welcome to Scrutiny CSPM CLI")
-    
+
     command_manager = CommandManager()
 
     # Load command plugins dynamically based on the Hydra configuration
@@ -21,19 +21,20 @@ def main(cfg: DictConfig) -> None:
         command_class = getattr(module, command_config.class_name)
         command_manager.register_command(command_name, command_class)
 
-    while True:
-        command = input("Enter a command (or 'quit' to exit): ")
+    # Set up argument parser
+    parser = argparse.ArgumentParser(description="Scrutiny CSPM CLI")
+    parser.add_argument("command", nargs='?', help="Command to execute (leave blank for interactive mode)")
+    parser.add_argument("args", nargs=argparse.REMAINDER, help="Arguments for the command")
+    args = parser.parse_args()
 
-        if command.lower() == "quit":
+    # Determine execution mode based on the command input
+    if args.command:
+        if args.command == 'quit':
             print("Exiting...")
-            break
-
-        command_parts = command.split()
-        command_name = command_parts[0]
-        command_args = command_parts[1:]
+            return
 
         try:
-            result = command_manager.execute_command(command_name, *command_args)
+            result = command_manager.execute_command(args.command, *args.args)
             if result is not None:
                 print(result)
         except ValueError as e:
@@ -41,7 +42,27 @@ def main(cfg: DictConfig) -> None:
             print("Available commands:")
             for cmd in command_manager.commands:
                 print(f"- {cmd}")
+    else:
+        # Enter interactive mode
+        while True:
+            command_input = input("Enter a command (or 'quit' to exit): ")
+            if command_input.lower() == "quit":
+                print("Exiting...")
+                break
 
+            command_parts = command_input.split()
+            command_name = command_parts[0]
+            command_args = command_parts[1:]
+
+            try:
+                result = command_manager.execute_command(command_name, *command_args)
+                if result is not None:
+                    print(result)
+            except ValueError as e:
+                print(f"Error: {str(e)}")
+                print("Available commands:")
+                for cmd in command_manager.commands:
+                    print(f"- {cmd}")
 
 if __name__ == "__main__":
     main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,15 @@ version: '3.8'
 name: 'scrutiny-cspm'
 
 services:
-  frontend:
-    build: ./frontend
+  app:
+    build: .
+    container_name: scrutiny-cspm
     ports:
       - "3000:3000"
     volumes:
       - ./scans:/scans
+  opa:
+    container_name: opa
+    image: openpolicyagent/opa:latest-debug
+    ports:
+      - "8181:8181"

--- a/frontend/src/app/dashboard/[scan]/results/actions.ts
+++ b/frontend/src/app/dashboard/[scan]/results/actions.ts
@@ -3,7 +3,6 @@ import { exec } from "node:child_process";
 import { Scan } from '@/types/scan';
 
 export async function getScan(id: string) {
-  const scan: Scan;
   try {
     const pythonProcess = exec(`python ../cli/main.py `);
     pythonProcess.kill();


### PR DESCRIPTION
Changes include:

1. Able to build the docker image on my machine
2. Add OPA support in instructions (docker compose)
3. Change CLI executable in readme from docker container
4. Also changes the CLI to able to run  `python cli.py inventory` as well for frontend support 